### PR TITLE
add more rooms and implemented some challenges

### DIFF
--- a/lib/cli/main.ex
+++ b/lib/cli/main.ex
@@ -8,7 +8,7 @@ defmodule CLI.Main do
     Shell.prompt("Press Enter to continue")
 
     HeroChoice.start()
-    |> crawl(DungeonCrawl.Room.all())
+    |> crawl(DungeonCrawl.Room.all(0))
   end
 
   defp welcome_message() do
@@ -31,22 +31,24 @@ defmodule CLI.Main do
 
   defp trigger_action({room, action}, character) do
     Shell.cmd("clear")
-    if room.trigger, do: room.trigger.run(character, action), else: {:none, character}
+    if room.trigger, do: room.trigger.run(character, action), else: {:forward, character}
   end
 
-  defp handle_action_result({:death, _}) do
+  defp handle_action_result({:death, character}) do
     Shell.cmd("clear")
     Shell.info("Unfortunately your wounds are too many to keep walking.")
     Shell.info("You fall onto the floor without strength to carry on.")
     Shell.info("Game over!")
+    Shell.info("Final score: #{character.score} points.")
     Shell.prompt("")
   end
 
-  defp handle_action_result({:exit, _}) do
+  defp handle_action_result({:exit, character}) do
     Shell.info("You found the exit. You won the game. Congratulations!")
+    Shell.info("Final score: #{character.score} points.")
   end
 
-  defp handle_action_result({_, character}) do
-    crawl(character, DungeonCrawl.Room.all())
+  defp handle_action_result({:forward, character}) do
+    crawl(character, DungeonCrawl.Room.all(character.score))
   end
 end

--- a/lib/dungeon_crawl/character.ex
+++ b/lib/dungeon_crawl/character.ex
@@ -6,7 +6,8 @@ defmodule DungeonCrawl.Character do
             hit_points: 0,
             max_hit_points: 0,
             attack_description: nil,
-            damage_range: nil
+            damage_range: nil,
+            score: 0
 
   @type t :: %Character{
           name: String.t(),
@@ -14,7 +15,8 @@ defmodule DungeonCrawl.Character do
           hit_points: non_neg_integer(),
           max_hit_points: non_neg_integer(),
           attack_description: String.t(),
-          damage_range: Range.t()
+          damage_range: Range.t(),
+          score: non_neg_integer()
         }
 
   @spec take_damage(character :: t(), amount :: non_neg_integer()) :: t()

--- a/lib/dungeon_crawl/room/room.ex
+++ b/lib/dungeon_crawl/room/room.ex
@@ -1,28 +1,66 @@
 defmodule DungeonCrawl.Room do
   alias __MODULE__
-  alias DungeonCrawl.Room.{Action}
-  alias DungeonCrawl.Room.Triggers
+  alias DungeonCrawl.Room.{Action, Trigger, Triggers}
 
   defstruct description: nil, actions: [], trigger: nil
 
   @type t :: %Room{description: String.t(), actions: list(Action.t()), trigger: Trigger}
 
-  @exit_room %{
-    description: "You can see the light of day. You found the exit!",
-    actions: [Action.forward()],
-    trigger: Triggers.Exit
-  }
+  def all(player_score) do
+    normal = generate_multiple_rooms(normal_room(), 10)
+    enemy = generate_multiple_rooms(enemy_room(), 14)
+    treasure = generate_multiple_rooms(treasure_room(), 4)
+    trap = generate_multiple_rooms(trap_room(), 4)
+    exit_ = generate_multiple_rooms(exit_room(), player_score * 1)
 
-  @enemy_room %{
-    description: "You can see an enemy blocking your path.",
-    actions: [Action.battle()],
-    trigger: Triggers.Enemy
-  }
+    [normal, enemy, treasure, trap, exit_]
+    |> Enum.concat()
+    |> Enum.shuffle()
+  end
 
-  @normal_room %{
-    description: "You found a quiet place. Looks safe for a little nap.",
-    actions: [Action.forward(), Action.rest()]
-  }
+  defp generate_multiple_rooms(room, quantity) do
+    [room]
+    |> Stream.cycle()
+    |> Enum.take(quantity)
+  end
 
-  def all(), do: [@exit_room, @enemy_room, @normal_room] |> Enum.map(&struct(Room, &1))
+  defp normal_room() do
+    %Room{
+      description: "You found a quiet place. Looks safe for a little nap.",
+      actions: [Action.forward(), Action.rest()],
+      trigger: Triggers.Rest
+    }
+  end
+
+  defp enemy_room() do
+    %Room{
+      description: "You can see an enemy blocking your path.",
+      actions: [Action.battle()],
+      trigger: Triggers.Enemy
+    }
+  end
+
+  defp treasure_room() do
+    %Room{
+      description: "Oh? this room looks different...\nMaybe there are secrets hidden there.",
+      actions: [Action.forward(), Action.search()],
+      trigger: Triggers.Treasure
+    }
+  end
+
+  defp trap_room() do
+    %Room{
+      description: "Oh? this room looks different...\nMaybe there are secrets hidden there.",
+      actions: [Action.forward(), Action.search()],
+      trigger: Triggers.Trap
+    }
+  end
+
+  defp exit_room() do
+    %Room{
+      description: "You can see the light of day. You found the exit!",
+      actions: [Action.forward()],
+      trigger: Triggers.Exit
+    }
+  end
 end

--- a/lib/dungeon_crawl/room/triggers/enemy.ex
+++ b/lib/dungeon_crawl/room/triggers/enemy.ex
@@ -16,8 +16,9 @@ defmodule DungeonCrawl.Room.Triggers.Enemy do
     |> show_message()
     |> step()
     |> case do
-      %Character{hit_points: 0} -> {:death, nil}
-      updated_character -> {:foward, updated_character}
+      # only the score matters when character dies
+      %Character{hit_points: 0} -> {:death, character}
+      updated -> {:forward, %Character{updated | score: updated.score + 1}}
     end
   end
 

--- a/lib/dungeon_crawl/room/triggers/rest.ex
+++ b/lib/dungeon_crawl/room/triggers/rest.ex
@@ -1,0 +1,21 @@
+defmodule DungeonCrawl.Room.Triggers.Rest do
+  @behaviour DungeonCrawl.Room.Trigger
+
+  alias DungeonCrawl.Character
+  alias DungeonCrawl.Room.Action
+  alias Mix.Shell.IO, as: Shell
+
+  def run(character, %Action{id: :forward}) do
+    Shell.info("You're walking cautiously and can see the next room.")
+    {:forward, character}
+  end
+
+  def run(character, %Action{id: :rest}) do
+    healing = 3
+
+    Shell.info("You search the room for a comfortable place to rest.")
+    Shell.info("After a little rest you regain #{healing} hit points.")
+
+    {:forward, Character.heal(character, healing)}
+  end
+end

--- a/lib/dungeon_crawl/room/triggers/trap.ex
+++ b/lib/dungeon_crawl/room/triggers/trap.ex
@@ -1,0 +1,26 @@
+defmodule DungeonCrawl.Room.Triggers.Trap do
+  @behaviour DungeonCrawl.Room.Trigger
+
+  alias DungeonCrawl.Character
+  alias DungeonCrawl.Room.Action
+  alias Mix.Shell.IO, as: Shell
+
+  def run(character, %Action{id: :forward}) do
+    Shell.info("You're walking cautiously and can see the next room.")
+    {:forward, character}
+  end
+
+  def run(character, %Action{id: :search}) do
+    damage = 3
+
+    Shell.info("You search the room looking for something useful.")
+    Shell.info("You step on a false floor and fall into a trap.")
+    Shell.info("You are hit by an arrow, losing #{damage} hit points.")
+
+    case Character.take_damage(character, 3) do
+      # only the score matters when character dies
+      %Character{hit_points: 0} -> {:death, character}
+      updated_character -> {:forward, updated_character}
+    end
+  end
+end

--- a/lib/dungeon_crawl/room/triggers/treasure.ex
+++ b/lib/dungeon_crawl/room/triggers/treasure.ex
@@ -1,0 +1,21 @@
+defmodule DungeonCrawl.Room.Triggers.Treasure do
+  @behaviour DungeonCrawl.Room.Trigger
+
+  alias DungeonCrawl.Character
+  alias DungeonCrawl.Room.Action
+  alias Mix.Shell.IO, as: Shell
+
+  def run(character, %Action{id: :forward}) do
+    {:forward, character}
+  end
+
+  def run(character, %Action{id: :search}) do
+    healing = 5
+
+    Shell.info("You search the room looking for something useful.")
+    Shell.info("You find a treasure box with a healing potion inside.")
+    Shell.info("You drink the potion and restore #{healing} hit points.")
+
+    {:forward, Character.heal(character, healing)}
+  end
+end


### PR DESCRIPTION
- [x] In the current game all the rooms have the same chance of appearing.
That means the exit room might show up immediately, leading to a very
short and dull game. Make it so certain rooms have a greater probability
of showing up than others do.

- [ ] Add an extra option at the beginning of the game to allow players to choose
the difficulty level. For example, when the player wants the game to be
hard, the exit and healing rooms will be difficult to find.

- [x] Implement a feature that changes the probability of the exit room
appearing based on how many places the hero has visited. For example,
at the beginning of the game the exit room will have no probability of
appearing, but after some certain number of rounds, the chances of it
appearing increase. (Depends on the amount of enemies defeated)

- [ ] Implement a scoring system. When the hero survives traps, defeats enemies, or finds treasures, the player’s score will increase. When the player beats the game, the score is saved in a file. The file must contain only the
top 10 scores.
- [ ] Make it so the hero can store items in his pocket to use later. For example,
he can pick up the healing potion in the treasure room and use it later,
when he’s lost hit points. Add an option to use the item when listing room
actions. It’s good to indicate the maximum number of items the hero can
accumulate.
- [ ] Improve the battle module by giving the player the option to run away or
attack in that round. When the hero is fleeing, he’ll receive one attack
from the enemy before making his escape.
